### PR TITLE
Update electron base app

### DIFF
--- a/com.lunarclient.LunarClient.yml
+++ b/com.lunarclient.LunarClient.yml
@@ -14,7 +14,6 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --socket=x11
-  - --socket=wayland
   - --socket=pulseaudio
   - --persist=.java
   - --talk-name=org.kde.StatusNotifierWatcher

--- a/com.lunarclient.LunarClient.yml
+++ b/com.lunarclient.LunarClient.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: lunarclient
 separate-locales: false
 rename-icon: lunarclient

--- a/com.lunarclient.LunarClient.yml
+++ b/com.lunarclient.LunarClient.yml
@@ -11,6 +11,7 @@ finish-args:
   - --persist=.minecraft
   - --persist=.lunarclient
   - --share=network
+  - --share=ipc
   - --device=dri
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
Please don't update one without updating the other

`--share=ipc` is required for x11 btw
`--socket=wayland` is not needed since neither minecraft of lunar client run on wayland, they run on xwayland