### PR TITLE
Fix Lunar Client 3.2.12 not launching

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -16,21 +16,6 @@ DEST="/app/extra/bin/"
 mkdir $DEST
 cp -r squashfs-root/* $DEST
 
-# Install icons
-
-ICON_DIR="/app/extra/export/share/icons/hicolor/"
-
-mkdir -p $ICON_DIR
-cp -r squashfs-root/usr/share/icons/hicolor/* $ICON_DIR
-
-iconSizes=("16" "32" "48" "64" "128" "256")
-
-for I in "${iconSizes[@]}"
-do
-	dir="$ICON_DIR/${I}x${I}/apps/"
-	mv "$dir/launcher.png" "$dir/com.lunarclient.LunarClient.png"
-done
-
 # Clean up
 rm -rf squashfs-root/
 rm $APP_IMAGE

--- a/com.lunarclient.LunarClient.yml
+++ b/com.lunarclient.LunarClient.yml
@@ -49,7 +49,7 @@ modules:
       - type: script
         dest-filename: lunarclient
         commands:
-          - exec zypak-wrapper /app/extra/bin/launcher --no-sandbox "$0"
+          - exec zypak-wrapper /app/extra/bin/lunarclient --no-sandbox "$0"
 
       - type: file
         path: com.lunarclient.LunarClient.appdata.xml

--- a/com.lunarclient.LunarClient.yml
+++ b/com.lunarclient.LunarClient.yml
@@ -11,6 +11,7 @@ finish-args:
   - --persist=.minecraft
   - --persist=.lunarclient
   - --share=network
+  - --share=ipc
   - --device=dri
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
The executable was renamed from `launcher` to `lunarclient` and the different size hicolor images are no longer bundled in the AppImage.


This is effectively a revert of #18 